### PR TITLE
[feat/select] Select 컴포넌트 생성 및 예시 추가

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,6 +4,7 @@
   import Avatar from "./components/avatar/Avatar.vue";
   import Badge from "./components/badge/Badge.vue";
   import TextField from "./components/input/TextField.vue";
+  import Select from "./components/select/Select.vue";
 
   /**
    * 클릭 이벤트 핸들러
@@ -35,6 +36,11 @@
   const usertext = ref("아이콘이 있는 input");
   const errorExample = ref("");
   const disabledExample = ref("값 비활성화");
+  /**
+   * select 박스의 반응형 값
+   */
+  const selectedFruit = ref("");
+  const selectedVagetable = ref("");
 </script>
 
 <template>
@@ -284,6 +290,35 @@
         ></TextField>
       </section>
     </form>
+  </article>
+
+  <!-- Select -->
+  <article>
+    <h2>Select</h2>
+    <h3>label이 있는 Select box</h3>
+    <section>
+      <Select
+        v-model="selectedFruit"
+        id="fruit"
+        name="fruit"
+        :options="['사과 🍎', '바나나 🍌', '포도 🍇', '키위 🥝', '수박 🍉', '오렌지 🍊']"
+        placeholder="과일을 선택하세요"
+        label="과일 선택"
+      >
+      </Select>
+    </section>
+    <h3>label이 없는 Select box</h3>
+    <section>
+      <Select
+        v-model="selectedVagetable"
+        id="vagetable"
+        name="vagetable"
+        :options="['배추 🥬', '오이 🥒', '당근 🥕', '가지 🍆', '토마토 🍅', '양파 🧅']"
+        placeholder="야채를 선택하세요"
+        ariaLabel="야채 선택"
+      >
+      </Select>
+    </section>
   </article>
 </template>
 

--- a/src/components/select/Select.scss
+++ b/src/components/select/Select.scss
@@ -1,0 +1,75 @@
+@use "/src/styles/abstracts/variables" as v;
+@use "/src/styles/abstracts/mixins" as m;
+
+.select-wrap {
+  width: 240px;
+  position: relative;
+
+  // select-wrap 선택된 값 영역
+  &__selected {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    padding: 8px 16px;
+    background: #fff;
+    border: 1px solid #e0e0e0;
+    box-sizing: border-box;
+    cursor: pointer;
+
+    .select-wrap__selected-value {
+      flex: 1;
+
+      &--placeholder {
+        opacity: 0.38;
+      }
+    }
+    .select-wrap__select-icon {
+      flex: none;
+      margin-left: auto;
+      width: 24px;
+      height: 24px;
+    }
+
+    &.opened {
+      border: 1px solid v.$primaryColor;
+      box-shadow: 0 0 0 1px v.$primaryColor inset;
+
+      .select-wrap__select-icon {
+        transform: rotate(180deg);
+      }
+    }
+    &.selected {
+      border: 1px solid #000;
+    }
+  }
+
+  // select-wrap 목록 영역
+  &__options {
+    position: absolute;
+    top: 44px;
+    left: 0;
+    width: 100%;
+    background: #fff;
+    box-shadow:
+      0px 5px 5px -3px rgba(0, 0, 0, 0.2),
+      0px 8px 10px 1px rgba(0, 0, 0, 0.14),
+      0px 3px 14px 2px rgba(0, 0, 0, 0.12);
+    z-index: 1;
+
+    &-list {
+      width: 100%;
+      padding: 8px 0;
+    }
+    &-list-item {
+      padding: 6px 16px;
+
+      &:hover {
+        background: rgba(0, 0, 0, 0.04);
+      }
+      &--placeholder {
+        padding: 6px 16px;
+        opacity: 0.38;
+      }
+    }
+  }
+}

--- a/src/components/select/Select.vue
+++ b/src/components/select/Select.vue
@@ -1,0 +1,142 @@
+<script setup>
+  import { ref, reactive, computed } from "vue";
+
+  const vModalValue = defineModel();
+
+  /**
+   * select 컴포넌트 Props 정의
+   * @property {String} id - select의 id 값
+   * @property {String} name - select의 name 값
+   * @property {Boolean} label - select의 label태그의 내용. 생략시 aria-label 또는 title 속성 필요
+   * @property {Boolean} ariaLabel - select만 있는 경우, select의 aria-label 속성 값. 생략시 title 속성 또는 label 태그의 내용 필요
+   * @property {Boolean} title - select만 있는 경우, select의 title 속성 값. 생략시 aria-label 속성 또는 label 태그의 내용 필요
+   * @property {String} placeholder - select의 placeholder
+   * @property {Boolean} isError - error 여부
+   * @property {String} errorMsg - error 값이 true일 경우 노출할 에러 메시지
+   * @property {Boolean} disabled - select의 disabled 여부
+   * @property {string[]} options - select의 options로 이루어진 배열
+   */
+  const rawProps = defineProps({
+    id: {
+      type: String,
+      required: true,
+    },
+    name: {
+      type: String,
+      required: true,
+    },
+    label: {
+      type: String,
+    },
+    ariaLabel: {
+      type: String,
+    },
+    title: {
+      type: String,
+    },
+    placeholder: {
+      type: String,
+      default: "선택하세요",
+    },
+    isError: {
+      type: Boolean,
+      default: false,
+    },
+    errorMsg: {
+      type: String,
+      default: "",
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    options: {
+      type: Array,
+      required: true,
+    },
+  });
+  const props = reactive(rawProps);
+
+  /** @type {boolean} - 셀렉트 박스 목록의 노출 여부 */
+  const isOpen = ref(false);
+  /**
+   * 셀렉트 박스 목록의 노출 목록 여부를 토글하는 함수
+   */
+  function toggleSelectIsOpen() {
+    isOpen.value = !isOpen.value;
+  }
+  /**
+   * 셀렉트 박스 목록의 값을 선택하는 목록 option 클릭 핸들러 함수
+   * @param {string} seletedOption - 목록에서 선택된 option
+   */
+  function handleClickOption(seletedOption) {
+    vModalValue.value = seletedOption;
+  }
+  /**
+   * 셀렉트 박스의 값을 나타내는 함수. 선택된 값이 없을시 placeholder 노출
+   */
+  const selectedValue = computed(() => {
+    return props.options.find((option) => option === vModalValue.value);
+  });
+  /**
+   * 셀렉트 박스의 label 처리. label이 없을 경우 셀렉트 박스에 aria-label로 대체
+   */
+  const ariaLabelAttributes = computed(() => {
+    if (props.label) return { "aria-labelledby": `select-${props.id}` };
+    else return { "aria-label": props.ariaLabel };
+  });
+</script>
+
+<template>
+  <!-- label (label이 있을 경우에만 렌더링) -->
+  <div v-if="props.label" :id="`select-${props.id}`" @click="toggleSelectIsOpen">{{ label }}</div>
+
+  <!-- select box -->
+  <div
+    class="select-wrap"
+    @click="toggleSelectIsOpen"
+    role="combobox"
+    :aria-expanded="isOpen"
+    :aria-controls="props.id"
+    aria-haspopup="listbox"
+    v-bind="ariaLabelAttributes"
+  >
+    <div class="select-wrap__selected" :class="{ opened: isOpen, selected: selectedValue }">
+      <span v-if="selectedValue" class="select-wrap__selected-value">
+        {{ selectedValue }}
+      </span>
+      <span v-else class="select-wrap__selected-value--placeholder">{{ props.placeholder }}</span>
+      <div class="select-wrap__select-icon">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          height="24px"
+          viewBox="0 -960 960 960"
+          width="24px"
+          fill="#000"
+        >
+          <path d="M480-360 280-560h400L480-360Z" />
+        </svg>
+      </div>
+    </div>
+    <div v-show="isOpen" class="select-wrap__options">
+      <ul class="select-wrap__options-list" role="listbox" :id="props.id">
+        <li class="select-wrap__options-list-item--placeholder">{{ placeholder }}</li>
+        <li
+          v-for="(option, index) in options"
+          :key="index"
+          class="select-wrap__options-list-item"
+          role="option"
+          :id="`option-${index}`"
+          :aria-selected="option === vModalValue"
+          @click="handleClickOption(option)"
+        >
+          {{ option }}
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+  @import "./Select.scss";
+</style>


### PR DESCRIPTION
커스텀 select box 컴포넌트를 생성하여 예시를 추가하였습니다.

- 실제 select, label태그를 사용하지 않으므로 접근성 요소 추가:
덕분에 WAI-ARIA를 비롯해 접근성에 대해 세세한 학습을 할 수 있었습니다.
- 가능한 한 심플한 컴포넌트를 만들기 위해 노력했습니다. vue에 대한 학습을 좀 더 세세히 할 수 있는 좋은 기회였습니다.

