### PR TITLE
[feat/checkbox] Checkbox 컴포넌트 생성 및 예시 추가

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,6 +5,7 @@
   import Badge from "./components/badge/Badge.vue";
   import TextField from "./components/input/TextField.vue";
   import Select from "./components/select/Select.vue";
+  import Checkbox from "./components/input/Checkbox.vue";
 
   /**
    * 클릭 이벤트 핸들러
@@ -36,6 +37,12 @@
   const usertext = ref("아이콘이 있는 input");
   const errorExample = ref("");
   const disabledExample = ref("값 비활성화");
+  /**
+   * Checkbox 컴포넌트에 사용될 반응형 값
+   */
+  const isCheckedhobby1 = ref(false);
+  const isCheckedhobby2 = ref(false);
+  const isCheckedhobby3 = ref(false);
   /**
    * select 박스의 반응형 값
    */
@@ -236,8 +243,8 @@
   <!-- Input -->
   <article>
     <h2>Input</h2>
-    <h3>Input - Text field (Input type text, password, number)</h3>
     <form>
+      <h3>Input - Text field (Input type text, password, number)</h3>
       <h4>Text field : Type별</h4>
       <section class="nowrap">
         <TextField v-model="username" id="username" name="username" label="사용자명"></TextField>
@@ -288,6 +295,31 @@
           label="비활성화된 Text Field"
           :disabled="true"
         ></TextField>
+      </section>
+
+      <h3>Input - Checkbox</h3>
+      <section>
+        <Checkbox
+          v-model="isCheckedhobby1"
+          id="hobby1"
+          name="hobby1"
+          label="취미1"
+          value="hobby1"
+        ></Checkbox>
+        <Checkbox
+          v-model="isCheckedhobby2"
+          id="hobby2"
+          name="hobby2"
+          label="취미2"
+          value="hobby2"
+        ></Checkbox>
+        <Checkbox
+          v-model="isCheckedhobby3"
+          id="hobby3"
+          name="hobby3"
+          label="취미3"
+          value="hobby3"
+        ></Checkbox>
       </section>
     </form>
   </article>
@@ -353,7 +385,7 @@
   h3 {
     position: relative;
     padding-left: 12px;
-    margin: 4px 0;
+    margin: 8px 0;
     font-size: 18px;
   }
   h3::before {

--- a/src/components/input/Checkbox.scss
+++ b/src/components/input/Checkbox.scss
@@ -1,0 +1,45 @@
+@use "/src/styles/abstracts/variables" as v;
+@use "/src/styles/abstracts/mixins" as m;
+
+.checkbox-wrap {
+  display: flex;
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+  cursor: pointer;
+
+  &__checkbox {
+    display: block;
+    width: 24px;
+    height: 24px;
+
+    &-icon {
+      width: 100%;
+      height: 100%;
+
+      &--checked {
+        fill: v.$primaryColor;
+      }
+      &--unchecked {
+        fill: #aaa;
+      }
+    }
+  }
+
+  &__label {
+    margin-left: 4px;
+    font-size: 14px;
+  }
+
+  input[type="checkbox"] {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    white-space: nowrap;
+    clip-path: inset(100%);
+    clip: rect(0 0 0 0);
+    overflow: hidden;
+  }
+}

--- a/src/components/input/Checkbox.vue
+++ b/src/components/input/Checkbox.vue
@@ -1,0 +1,71 @@
+<script setup>
+  import { reactive } from "vue";
+
+  const vModelValue = defineModel();
+
+  /**
+   * Input Checkbox 컴포넌트 Props 정의
+   * @property {String} id - input의 id 값
+   * @property {String} name - input의 name 값
+   * @property {Boolean} label - input의 label태그의 내용
+   * @property {String} value - input의 값
+   * @property {Boolean} disabled - input의 disabled 여부
+   */
+  const rawProps = defineProps({
+    id: {
+      type: String,
+      required: true,
+    },
+    name: {
+      type: String,
+      required: true,
+    },
+    label: {
+      type: String,
+    },
+    value: {
+      type: String,
+      required: true,
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+  });
+  const props = reactive(rawProps);
+</script>
+
+<template>
+  <label class="checkbox-wrap">
+    <input type="checkbox" v-model="vModelValue" :id="props.id" :name="props.name" />
+    <span class="checkbox-wrap__checkbox" :class="vModelValue ? 'checked' : ''">
+      <!-- checked icon -->
+      <svg
+        v-if="vModelValue"
+        class="checkbox-wrap__checkbox-icon checkbox-wrap__checkbox-icon--checked"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 -960 960 960"
+      >
+        <path
+          d="m424-312 282-282-56-56-226 226-114-114-56 56 170 170ZM200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h560q33 0 56.5 23.5T840-760v560q0 33-23.5 56.5T760-120H200Z"
+        />
+      </svg>
+      <!-- unchecked icon -->
+      <svg
+        v-else
+        class="checkbox-wrap__checkbox-icon checkbox-wrap__checkbox-icon--unchecked"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 -960 960 960"
+      >
+        <path
+          d="M200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h560q33 0 56.5 23.5T840-760v560q0 33-23.5 56.5T760-120H200Zm0-80h560v-560H200v560Z"
+        />
+      </svg>
+    </span>
+    <span class="checkbox-wrap__label">{{ props.label }}</span>
+  </label>
+</template>
+
+<style scoped>
+  @import "./Checkbox.scss";
+</style>


### PR DESCRIPTION
Checkbox 컴포넌트 생성 후 예시를 추가하였습니다.

label태그 안에 input 태그를 넣게 되면 label에 for 속성을 쓸 필요 없다는 것을 처음 알았습니다.
그리고 Input 태그가 실제로 체크되더라도 커스텀하게 되면 브라우저의 input에 checked가 안뜨는 현상을 발견했습니다만, 실제로는 이상이 없었습니다. 이 현상은 MUI에 있는 input에도 마찬가지였습니다.

GPT로 확인해본 결과, 브라우저의 Elements 탭은 HTML 속성(attribute)만 보여주기 때문에 생긴 현상이었습니다. “checked 속성”이 아니라 “checked 프로퍼티”만 변경된 상태이기 때문입니다. 체크박스 컴포넌트를 커스터마이징 하게 되면서 input의 프로퍼티를 checked로 바꾸었지 HTML 속성은 건들지 않았기 때문에 elements 탭에서는 보이지 않아도 실제로는 체크된 값을 받아올 수 있었던 것입니다. 